### PR TITLE
fix(recipe): comment out Firefox RPM removal & flatpak install (#20)

### DIFF
--- a/config/recipe.yml
+++ b/config/recipe.yml
@@ -23,8 +23,10 @@ modules:
       # - micro
       # - starship
     remove:
-      - firefox # default firefox removed in favor of flatpak
-      - firefox-langpacks # langpacks needs to also be removed to prevent dependency problems
+      # example: removing firefox (in favor of the flatpak)
+      # "firefox" is the main package, "firefox-langpacks" is a dependency
+      # - firefox
+      # - firefox-langpacks # also remove firefox dependency (not required for all packages, this is a special case)
 
   - type: default-flatpaks
     notify: true # Send notification after install/uninstall is finished (true/false)
@@ -34,7 +36,7 @@ modules:
       # repo-name: flathub
       # repo-title: "Flathub (system-wide)" # Optional; this sets the remote's user-facing name in graphical frontends like GNOME Software
       install:
-        - org.mozilla.firefox
+        # - org.mozilla.firefox
         # - org.gnome.Loupe
         # - one.ablaze.floorp//lightning # This is an example of flatpak which has multiple branches in selection (flatpak//branch).
       # Flatpak runtimes are not supported (like org.winehq.Wine//stable-23.08),


### PR DESCRIPTION
* fix(recipe): Uncomment Firefox RPM removal

Firefox RPM removal is an opinionated choice, which should be represented as an example of how to remove RPM package properly, not as a "rule".

Solves:
https://github.com/blue-build/template/issues/16

* fix(recipe): Also exclude Firefox from default-flatpaks & add more detailed RPM removal comment

* fix(recipe): Formatting

* fix: streamline comment on ff removal

---------